### PR TITLE
Modify the standings screen to fit a W or L for better readability

### DIFF
--- a/renderers/standings.py
+++ b/renderers/standings.py
@@ -13,15 +13,18 @@ def render(matrix, canvas, division):
   starttime = time.time()
   while True:
     offset = 6
+    graphics.DrawText(canvas, font, 28, offset, text_color, stat.upper())
     for team in division.teams:
       abbrev = '{:3s}'.format(team.team_abbrev)
-      text = '%s %s' % (abbrev, getattr(team, stat))
-      graphics.DrawText(canvas, font, 1, offset, text_color, text)
+      team_text = '%s' % abbrev
+      stat_text = '%s' % getattr(team, stat)
+      graphics.DrawText(canvas, font, 1 , offset, text_color, team_text)
+      graphics.DrawText(canvas, font, 15, offset, text_color, stat_text)
 
       for x in range(0, canvas.width):
         canvas.SetPixel(x, offset, *ledcolors.standings.divider)
       for y in range(0, canvas.height):
-        canvas.SetPixel(14, y, *ledcolors.standings.divider)
+        canvas.SetPixel(13, y, *ledcolors.standings.divider)
       offset += 6
 
     matrix.SwapOnVSync(canvas)


### PR DESCRIPTION
This just moves things over on the standings screen enough to fit a W or L in the top right of the screen. Tested with 3 digit wins and still works. I really feel like the readability is improved this way. I also tried adding a W/L to the end of each line and it just looked a lot more cluttered (for obvious reasons)