### PR TITLE
Manually abbreviate team names when the pregame fails to find an overview

### DIFF
--- a/data/pregame.py
+++ b/data/pregame.py
@@ -8,12 +8,20 @@ class Pregame:
   def __pregame_data(self):
     # The overview API is used to get the teams' abbreviations
     # as opposed to the full names
-    overview = mlbgame.overview(self.game.game_id)
-
     game_data = {}
-    game_data['away_team'] = overview.away_name_abbrev
-    game_data['home_team'] = overview.home_name_abbrev
+
+    try:
+      overview = mlbgame.overview(self.game.game_id)
+      game_data['away_team'] = overview.away_name_abbrev
+      game_data['home_team'] = overview.home_name_abbrev
+    except ValueError:
+      # We can't find the overview page. Let's just abbreviate the teams manually
+      game_data['away_team'] = self.game.away_team[:3]
+      game_data['home_team'] = self.game.home_team[:3]
+      game_data['error'] = "Game Data Not Found"
+
     game_data['time'] = self.game.game_start_time
     game_data['away_pitcher'] = self.game.p_pitcher_away or 'TBD'
     game_data['home_pitcher'] = self.game.p_pitcher_home or 'TBD'
+
     return game_data

--- a/renderers/pregame.py
+++ b/renderers/pregame.py
@@ -29,4 +29,6 @@ class Pregame:
 
   def __render_probable_starters(self):
     pitchers_text = self.game.game_data['away_pitcher'] + ' vs ' + self.game.game_data['home_pitcher']
+    if 'error' in self.game.game_data:
+      pitchers_text += '  ' + self.game.game_data['error']
     return graphics.DrawText(self.canvas, self.font, self.probable_starter_pos, 25, self.text_color, pitchers_text)


### PR DESCRIPTION
Some of these nonsense games aren't returning any overview at all. This probably won't be an issue during the regular season but it's probably a good idea to fail more gracefully anyways. I also append an error message after the pitchers scroll but this will rely on #30 for there to be enough time to actually see the message if rotation is enabled.