### PR TITLE
Use overview data for everything, fix rendering refresh rate

### DIFF
--- a/data/bases.py
+++ b/data/bases.py
@@ -1,0 +1,24 @@
+class Bases:
+  def __init__(self, overview):
+    b1 = None
+    b2 = None
+    b3 = None
+
+    try:
+      b1 = overview.runner_on_1b
+    except AttributeError:
+      pass
+
+    try:
+      b2 = overview.runner_on_2b
+    except AttributeError:
+      pass
+
+    try:
+      b3 = overview.runner_on_3b
+    except AttributeError:
+      pass
+    self.runners = [b1, b2, b3]
+
+  def __str__(self):
+    return ', '.join(str(runner) for runner in self.runners)

--- a/data/inning.py
+++ b/data/inning.py
@@ -1,0 +1,4 @@
+class Inning:
+  def __init__(self, overview):
+    self.number = overview.inning
+    self.state = overview.inning_state

--- a/data/outs.py
+++ b/data/outs.py
@@ -1,0 +1,3 @@
+class Outs:
+  def __init__(self, overview):
+    self.number = overview.outs

--- a/data/pitches.py
+++ b/data/pitches.py
@@ -1,0 +1,4 @@
+class Pitches:
+  def __init__(self, overview):
+    self.balls = overview.balls
+    self.strikes = overview.strikes

--- a/data/pregame.py
+++ b/data/pregame.py
@@ -2,39 +2,25 @@ import mlbgame
 import debug
 
 class Pregame:
-  def __init__(self, game):
-    self.game = game
-    self.game_data = self.__pregame_data()
-    debug.log(self)
-  
-  def __pregame_data(self):
-    # The overview API is used to get the teams' abbreviations
-    # as opposed to the full names
-    game_data = {}
+  def __init__(self, overview):
+    self.home_team = overview.home_name_abbrev
+    self.away_team = overview.away_name_abbrev
+    self.start_time = overview.time + overview.ampm
 
     try:
-      overview = mlbgame.overview(self.game.game_id)
-      game_data['away_team'] = overview.away_name_abbrev
-      game_data['home_team'] = overview.home_name_abbrev
-    except ValueError:
-      # We can't find the overview page. Let's just abbreviate the teams manually
-      game_data['away_team'] = self.game.away_team[:3]
-      game_data['home_team'] = self.game.home_team[:3]
-      game_data['error'] = "Game Data Not Found"
+      self.away_starter = overview.away_probable_pitcher_last_name or 'TBD'
+    except:
+      self.away_starter = 'TBD'
 
-    game_data['time'] = self.game.game_start_time
-    game_data['away_pitcher'] = self.game.p_pitcher_away or 'TBD'
-    game_data['home_pitcher'] = self.game.p_pitcher_home or 'TBD'
-
-    return game_data
+    try:
+      self.home_starter = overview.home_probable_pitcher_last_name or 'TBD'
+    except:
+      self.home_starter = 'TBD'
+    debug.log(self)
 
   def __str__(self):
     s =  "<%s %s> " % (self.__class__.__name__, hex(id(self)))
     s += "%s @ %s, (%s), %s vs %s" % (
-      self.game_data['away_team'], self.game_data['home_team'], self.game_data['time'], 
-      self.game_data['away_pitcher'], self.game_data['home_pitcher'])
-
-    if 'error' in self.game_data:
-      s += ", Error: %s" % (self.game_data['error'])
-
+      self.away_team, self.home_team, self.start_time,
+      self.away_starter, self.home_starter)
     return s

--- a/data/scoreboard.py
+++ b/data/scoreboard.py
@@ -1,4 +1,8 @@
-import mlbgame
+from bases import Bases
+from inning import Inning
+from pitches import Pitches
+from outs import Outs
+from team import Team
 import datetime
 import debug
 
@@ -7,69 +11,27 @@ class Scoreboard:
   The data contains runs scored for both teams, and details about the current at-bat,
   including runners on base, balls, strikes, and outs.
   """
-  def __init__(self, game):
-    """ Constructs a new Scoreboard and fetches data from MLB.
 
-    game - The game to display.
-    """
-    self.game = game
-    self.game_data = self.__current_game_data(game)
+  def __init__(self, overview):
+    self.away_team = Team(overview.away_name_abbrev, overview.away_team_runs)
+    self.home_team = Team(overview.home_name_abbrev, overview.home_team_runs)
+    self.inning = Inning(overview)
+    self.bases = Bases(overview)
+    self.pitches = Pitches(overview)
+    self.outs = Outs(overview)
+    self.game_status = overview.status
     debug.log(self)
-
-  def __current_game_data(self, game):
-    game_id = game.game_id
-
-    overview = mlbgame.overview(game_id)
-    game_data = {}
-    game_data['away_team'] = overview.away_name_abbrev
-    game_data['home_team'] = overview.home_name_abbrev
-    try:
-      game_data['inning'] = self.__current_inning(game_id)
-    except ValueError:
-      print('No game data could be found for %s @ %s' % (game_data['away_team'], game_data['home_team']))
-      return False
-    return game_data
-
-  def __current_inning(self, game_id):
-    innings = mlbgame.game_events(game_id)
-
-    inning_status = {}
-    inning_status['number'] = len(innings)
-
-    current_inning = innings[-1]
-    is_bottom = bool(len(current_inning.bottom))
-    at_bats = current_inning.bottom if is_bottom else current_inning.top
-
-    inning_status['bottom'] = is_bottom
-    inning_status['at_bat'] = self.__current_at_bat(at_bats[-1])
-    return inning_status
-
-  def __current_at_bat(self, current_at_bat):
-    at_bat = {}
-    at_bat['away_team_runs'] = current_at_bat.away_team_runs
-    at_bat['home_team_runs'] = current_at_bat.home_team_runs
-    at_bat['outs'] = current_at_bat.o
-    at_bat['balls'] = current_at_bat.b
-    at_bat['strikes'] = current_at_bat.s
-    at_bat['bases'] = self.__runners_on_base(current_at_bat)
-    return at_bat
-
-  def __runners_on_base(self, at_bat):
-    runners = []
-    runners.append(bool(at_bat.b1))
-    runners.append(bool(at_bat.b2))
-    runners.append(bool(at_bat.b3))
-    return runners
 
   def __str__(self):
     s = "<%s %s> " % (self.__class__.__name__, hex(id(self)))
-    s += "%s (%s) @ %s (%s), Inning: %s (Bot: %s), B:%s S:%s O:%s, Bases: %s" % (
-      self.game_data['away_team'], str(self.game_data['inning']['at_bat']['away_team_runs']),
-      self.game_data['home_team'], str(self.game_data['inning']['at_bat']['home_team_runs']),
-      str(self.game_data['inning']['number']), 
-      str(self.game_data['inning']['bottom']),
-      str(self.game_data['inning']['at_bat']['balls']),
-      str(self.game_data['inning']['at_bat']['strikes']),
-      str(self.game_data['inning']['at_bat']['outs']),
-      str(self.game_data['inning']['at_bat']['bases']))
+    s += "%s (%s) @ %s (%s), Status: %s, Inning: (Number, %s, State: %s), B:%s S:%s O:%s, Bases: %s" % (
+      self.away_team.team_name, str(self.away_team.runs),
+      self.home_team.team_name, str(self.home_team.runs),
+      self.game_status,
+      str(self.inning.number),
+      str(self.inning.state),
+      str(self.pitches.balls),
+      str(self.pitches.strikes),
+      str(self.outs.number),
+      str(self.bases))
     return s

--- a/data/team.py
+++ b/data/team.py
@@ -1,0 +1,4 @@
+class Team:
+  def __init__(self, team_name, runs):
+    self.team_name = team_name
+    self.runs = runs

--- a/renderers/pregame.py
+++ b/renderers/pregame.py
@@ -10,25 +10,24 @@ class Pregame:
     self.text_color = graphics.Color(*ledcolors.scoreboard.text)
     self.probable_starter_pos = probable_starter_pos
 
+
   def render(self):
     self.__render_matchup()
     self.__render_start_time()
     return self.__render_probable_starters()
 
   def __render_matchup(self):
-    away_text = '{:>3s}'.format(self.game.game_data['away_team'])
-    home_text = '{:3s}'.format(self.game.game_data['home_team'])
+    away_text = '{:>3s}'.format(self.game.away_team)
+    home_text = '{:3s}'.format(self.game.home_team)
 
     graphics.DrawText(self.canvas, self.font, 1, 6, self.text_color, away_text)
     graphics.DrawText(self.canvas, self.font, 15, 6, self.text_color, '@')
     graphics.DrawText(self.canvas, self.font, 20, 6, self.text_color, home_text)
 
   def __render_start_time(self):
-    time_text = '{:7s}'.format(self.game.game_data['time'])
-    graphics.DrawText(self.canvas, self.font, 5, 13, self.text_color, self.game.game_data['time'])
+    time_text = '{:7s}'.format(self.game.start_time)
+    graphics.DrawText(self.canvas, self.font, 5, 13, self.text_color, time_text)
 
   def __render_probable_starters(self):
-    pitchers_text = self.game.game_data['away_pitcher'] + ' vs ' + self.game.game_data['home_pitcher']
-    if 'error' in self.game.game_data:
-      pitchers_text += '  ' + self.game.game_data['error']
+    pitchers_text = self.game.away_starter + ' vs ' + self.game.home_starter
     return graphics.DrawText(self.canvas, self.font, self.probable_starter_pos, 25, self.text_color, pitchers_text)


### PR DESCRIPTION
Fixes #49 
Fixes #50 

Use overview data for everything. This removes the usage of the nested attributes from the `games` and `game_events` APIs, as it was incredibly errorprone and the data was often inaccurate.

Another fix in here is the games refreshing at half the rate as it should've been. Things were taking 30 seconds instead of 15 to rotate.