### PR TITLE
Split out scoreboard renderer into separate renderers

### DIFF
--- a/renderers/bases.py
+++ b/renderers/bases.py
@@ -1,0 +1,46 @@
+import ledcolors.scoreboard
+
+class BasesRenderer:
+  """Renders the bases on the scoreboard and fills them in if they
+  currently hold a runner."""
+
+  def __init__(self, canvas, bases):
+    self.canvas = canvas
+    self.bases = bases
+
+  def render(self):
+    base_runners = self.bases.runners
+    base_px = []
+    base_px.append({'x': 26, 'y': 27} )
+    base_px.append({'x': 21, 'y': 22} )
+    base_px.append({'x': 16, 'y': 27} )
+
+    for base in range(len(base_runners)):
+      self.__render_base_outline(base_px[base])
+
+      # Fill in the base if there's currently a baserunner
+      if base_runners[base]:
+        self.__render_baserunner(base_px[base])
+
+  def __render_base_outline(self, base):
+    # Hollow diamonds are a popular homework problem but IDGAF
+    self.canvas.SetPixel(base['x'] - 3, base['y'], *ledcolors.scoreboard.text)
+    self.canvas.SetPixel(base['x'] - 2, base['y'] - 1, *ledcolors.scoreboard.text)
+    self.canvas.SetPixel(base['x'] - 2, base['y'] + 1, *ledcolors.scoreboard.text)
+    self.canvas.SetPixel(base['x'] - 1, base['y'] - 2, *ledcolors.scoreboard.text)
+    self.canvas.SetPixel(base['x'] - 1, base['y'] + 2, *ledcolors.scoreboard.text)
+    self.canvas.SetPixel(base['x'], base['y'] - 3, *ledcolors.scoreboard.text)
+    self.canvas.SetPixel(base['x'], base['y'] + 3, *ledcolors.scoreboard.text)
+    self.canvas.SetPixel(base['x'] + 1, base['y'] - 2, *ledcolors.scoreboard.text)
+    self.canvas.SetPixel(base['x'] + 1, base['y'] + 2, *ledcolors.scoreboard.text)
+    self.canvas.SetPixel(base['x'] + 2, base['y'] - 1, *ledcolors.scoreboard.text)
+    self.canvas.SetPixel(base['x'] + 2, base['y'] + 1, *ledcolors.scoreboard.text)
+    self.canvas.SetPixel(base['x'] + 3, base['y'], *ledcolors.scoreboard.text)
+
+  def __render_baserunner(self, base):
+    offset = 2
+    for x in range(-offset, offset + 1):
+      for y in range(-offset, offset + 1):
+        if abs(x) == offset and abs(y) == offset:
+          continue
+        self.canvas.SetPixel(base['x'] + x, base['y'] + y, *ledcolors.scoreboard.text)

--- a/renderers/inning.py
+++ b/renderers/inning.py
@@ -1,0 +1,42 @@
+from rgbmatrix import graphics
+from utils import get_font
+import ledcolors.scoreboard
+
+# Because normal games are 9 innings, silly
+NORMAL_GAME_LENGTH = 9
+
+# Inning states
+BOTTOM = 'Bottom'
+END = 'End'
+MIDDLE = 'Middle'
+TOP = 'Top'
+
+class InningRenderer:
+  """Renders the inning and inning arrow on the scoreboard."""
+
+  def __init__(self, canvas, inning):
+    self.canvas = canvas
+    self.inning = inning
+    self.font = get_font()
+
+  def render(self):
+    number_color = graphics.Color(*ledcolors.scoreboard.text)
+    pos_x = 28 if self.inning.number <= NORMAL_GAME_LENGTH else 24
+    graphics.DrawText(self.canvas, self.font, pos_x, 20, number_color, str(self.inning.number))
+
+    self.__render_inning_half()
+
+  def __render_inning_half(self):
+    tri_px = {'x': 24, 'y': 16}
+    if self.inning.number > NORMAL_GAME_LENGTH:
+      tri_px['x'] = 20
+
+    offset = 2
+    for x in range(-offset, offset + 1):
+      self.canvas.SetPixel(tri_px['x'] + x, tri_px['y'], *ledcolors.scoreboard.text)
+
+    offset = 1 if self.inning.state == BOTTOM else -1
+    self.canvas.SetPixel(tri_px['x'] - 1, tri_px['y'] + offset, *ledcolors.scoreboard.text)
+    self.canvas.SetPixel(tri_px['x'], tri_px['y'] + offset, *ledcolors.scoreboard.text)
+    self.canvas.SetPixel(tri_px['x'] + 1, tri_px['y'] + offset, *ledcolors.scoreboard.text)
+    self.canvas.SetPixel(tri_px['x'], tri_px['y'] + offset + offset, *ledcolors.scoreboard.text)

--- a/renderers/outs.py
+++ b/renderers/outs.py
@@ -1,0 +1,30 @@
+import ledcolors.scoreboard
+
+class OutsRenderer:
+  """Renders the out circles on the scoreboard."""
+
+  def __init__(self, canvas, outs):
+    self.canvas = canvas
+    self.outs = outs
+
+  def render(self):
+    out_px = []
+    out_px.append({'x': 2, 'y': 27})
+    out_px.append({'x': 6, 'y': 27})
+    out_px.append({'x': 10, 'y': 27})
+    for out in range(len(out_px)):
+      self.__render_out_circle(out_px[out])
+      # Fill in the circle if that out has occurred
+      if (self.outs.number > out):
+        self.canvas.SetPixel(
+            out_px[out]['x'], out_px[out]['y'], *ledcolors.scoreboard.text)
+
+  def __render_out_circle(self, out):
+    offset = 1
+    for x in range(-offset, offset + 1):
+      for y in range(-offset, offset + 1):
+        # The dead center is filled in only if that many outs has occurred, and happens above
+        # after this circle is rendered
+        if x == 0 and y == 0:
+          continue
+        self.canvas.SetPixel(out['x'] + x, out['y'] + y, *ledcolors.scoreboard.text)

--- a/renderers/pitches.py
+++ b/renderers/pitches.py
@@ -1,0 +1,15 @@
+from rgbmatrix import graphics
+from utils import get_font
+import ledcolors.scoreboard
+
+class PitchesRenderer:
+  """Renders balls and strikes on the scoreboard."""
+
+  def __init__(self, canvas, pitches):
+    self.canvas = canvas
+    self.pitches = pitches
+    self.font = get_font()
+
+  def render(self):
+    pitches_color = graphics.Color(*ledcolors.scoreboard.text)
+    graphics.DrawText(self.canvas, self.font, 1, 23, pitches_color, str(self.pitches.balls) + '-' + str(self.pitches.strikes))

--- a/renderers/scoreboard.py
+++ b/renderers/scoreboard.py
@@ -1,145 +1,20 @@
-from rgbmatrix import graphics
-from utils import get_font, get_team_colors
-import ledcolors.scoreboard
-
-# Inning states
-BOTTOM = 'Bottom'
-END = 'End'
-MIDDLE= 'Middle'
-TOP = 'Top'
+from renderers.bases import BasesRenderer
+from renderers.inning import InningRenderer
+from renderers.outs import OutsRenderer
+from renderers.pitches import PitchesRenderer
+from renderers.teams import TeamsRenderer
 
 class Scoreboard:
   def __init__(self, canvas, scoreboard):
     self.canvas = canvas
     self.scoreboard = scoreboard
-    self.colors = get_team_colors()
-    self.font = get_font()
 
   def render(self):
-    self.__render_team_colors()
-    self.__render_team_text()
-    self.__render_inning()
+    TeamsRenderer(self.canvas, self.scoreboard.home_team, self.scoreboard.away_team).render()
+    InningRenderer(self.canvas, self.scoreboard.inning).render()
 
     # TODO: Don't render these if the inning state isn't top or bottom
     # Render a Final or End/Middle of Inning instead
-    self.__render_pitches()
-    self.__render_outs()
-    self.__render_bases()
-
-  def __team_color_data(self, team_name):
-    return self.colors.get(team_name.lower(), self.colors['default'])
-
-  def __render_team_colors(self):
-    away_team_color_data = self.__team_color_data(self.scoreboard.away_team.team_name)
-    away_team_color = away_team_color_data['home']
-
-    home_team_color_data = self.__team_color_data(self.scoreboard.home_team.team_name)
-    home_team_color = home_team_color_data['home']
-
-    scores_height = 14
-    for x in range(self.canvas.width):
-      for y in range(scores_height):
-        color = home_team_color if y >= scores_height / 2 else away_team_color
-        self.canvas.SetPixel(x, y, color['r'], color['g'], color['b'])
-
-  def __render_team_text(self):
-    away_team = self.scoreboard.away_team
-    away_team_color_data = self.__team_color_data(away_team.team_name)
-    away_text_color = away_team_color_data.get('text', self.colors['default']['text'])
-    away_text_color_graphic = graphics.Color(away_text_color['r'], away_text_color['g'], away_text_color['b'])
-    away_text = '{:3s}'.format(away_team.team_name.upper()) + ' ' + str(away_team.runs)
-
-    home_team = self.scoreboard.home_team
-    home_team_color_data = self.__team_color_data(home_team.team_name)
-    home_text_color = home_team_color_data.get('text', self.colors['default']['text'])
-    home_text_color_graphic = graphics.Color(home_text_color['r'], home_text_color['g'], home_text_color['b'])
-    home_text = '{:3s}'.format(home_team.team_name.upper()) + ' ' + str(home_team.runs)
-
-    graphics.DrawText(self.canvas, self.font, 1, 6, away_text_color_graphic, away_text)
-    graphics.DrawText(self.canvas, self.font, 1, 13, home_text_color_graphic, home_text)
-
-  def __render_pitches(self):
-    pitches = self.scoreboard.pitches
-    pitches_color = graphics.Color(*ledcolors.scoreboard.text)
-    graphics.DrawText(self.canvas, self.font, 1, 23, pitches_color, str(pitches.balls) + '-' + str(pitches.strikes))
-
-  def __render_outs(self):
-    outs = self.scoreboard.outs
-    out_px = []
-    out_px.append({'x': 2, 'y': 27})
-    out_px.append({'x': 6, 'y': 27})
-    out_px.append({'x': 10, 'y': 27})
-    for out in range(len(out_px)):
-      self.__render_out_circle(out_px[out])
-      # Fill in the circle if that out has occurred
-      if (outs.number > out):
-        self.canvas.SetPixel(out_px[out]['x'], out_px[out]['y'], *ledcolors.scoreboard.text)
-
-  def __render_bases(self):
-    bases = self.scoreboard.bases.runners
-    base_px = []
-    base_px.append({'x': 26, 'y': 27} )
-    base_px.append({'x': 21, 'y': 22} )
-    base_px.append({'x': 16, 'y': 27} )
-
-    for base in range(len(bases)):
-      self.__render_base_outline(base_px[base])
-
-      # Fill in the base if there's currently a baserunner
-      if bases[base]:
-        self.__render_baserunner(base_px[base])
-
-  def __render_inning(self):
-    inning = self.scoreboard.inning
-    self.__render_inning_half(inning)
-    number_color = graphics.Color(*ledcolors.scoreboard.text)
-    pos_x = 28
-    if inning.number > 9:
-      pos_x = 24
-    graphics.DrawText(self.canvas, self.font, pos_x, 20, number_color, str(inning.number))
-
-  def __render_out_circle(self, out):
-    offset = 1
-    for x in range(-offset, offset + 1):
-      for y in range(-offset, offset + 1):
-        # The dead center is filled in only if that many outs has occurred, and happens elsewhere
-        if x == 0 and y == 0:
-          continue
-        self.canvas.SetPixel(out['x'] + x, out['y'] + y, *ledcolors.scoreboard.text)
-
-  def __render_base_outline(self, base):
-    # Hollow diamonds are a popular homework problem but IDGAF
-    self.canvas.SetPixel(base['x'] - 3, base['y'], *ledcolors.scoreboard.text)
-    self.canvas.SetPixel(base['x'] - 2, base['y'] - 1, *ledcolors.scoreboard.text)
-    self.canvas.SetPixel(base['x'] - 2, base['y'] + 1, *ledcolors.scoreboard.text)
-    self.canvas.SetPixel(base['x'] - 1, base['y'] - 2, *ledcolors.scoreboard.text)
-    self.canvas.SetPixel(base['x'] - 1, base['y'] + 2, *ledcolors.scoreboard.text)
-    self.canvas.SetPixel(base['x'], base['y'] - 3, *ledcolors.scoreboard.text)
-    self.canvas.SetPixel(base['x'], base['y'] + 3, *ledcolors.scoreboard.text)
-    self.canvas.SetPixel(base['x'] + 1, base['y'] - 2, *ledcolors.scoreboard.text)
-    self.canvas.SetPixel(base['x'] + 1, base['y'] + 2, *ledcolors.scoreboard.text)
-    self.canvas.SetPixel(base['x'] + 2, base['y'] - 1, *ledcolors.scoreboard.text)
-    self.canvas.SetPixel(base['x'] + 2, base['y'] + 1, *ledcolors.scoreboard.text)
-    self.canvas.SetPixel(base['x'] + 3, base['y'], *ledcolors.scoreboard.text)
-
-  def __render_baserunner(self, base):
-    offset = 2
-    for x in range(-offset, offset + 1):
-      for y in range(-offset, offset + 1):
-        if abs(x) == offset and abs(y) == offset:
-          continue
-        self.canvas.SetPixel(base['x'] + x, base['y'] + y, *ledcolors.scoreboard.text)
-
-  def __render_inning_half(self, inning):
-    tri_px = {'x': 24, 'y': 16}
-    if inning.number > 9:
-      tri_px['x'] = 20
-    offset = 2
-    for x in range(-offset, offset + 1):
-      self.canvas.SetPixel(tri_px['x'] + x, tri_px['y'], *ledcolors.scoreboard.text)
-
-    offset = 1 if inning.state == BOTTOM else -1
-    self.canvas.SetPixel(tri_px['x'] - 1, tri_px['y'] + offset, *ledcolors.scoreboard.text)
-    self.canvas.SetPixel(tri_px['x'], tri_px['y'] + offset, *ledcolors.scoreboard.text)
-    self.canvas.SetPixel(tri_px['x'] + 1, tri_px['y'] + offset, *ledcolors.scoreboard.text)
-    self.canvas.SetPixel(tri_px['x'], tri_px['y'] + offset + offset, *ledcolors.scoreboard.text)
+    PitchesRenderer(self.canvas, self.scoreboard.pitches).render()
+    OutsRenderer(self.canvas, self.scoreboard.outs).render()
+    BasesRenderer(self.canvas, self.scoreboard.bases).render()

--- a/renderers/teams.py
+++ b/renderers/teams.py
@@ -1,0 +1,40 @@
+from rgbmatrix import graphics
+from utils import get_font, get_file
+import json
+
+class TeamsRenderer:
+  """Renders the scoreboard team banners including background color, team abbreviation text,
+  and their scored runs."""
+
+  def __init__(self, canvas, home_team, away_team):
+    self.canvas = canvas
+    self.home_team = home_team
+    self.away_team = away_team
+
+    self.colors = json.load(open(get_file('Assets/colors.json')))
+    self.font = get_font()
+
+  def __team_colors(self, team_name):
+    return self.colors.get(team_name.lower(), self.colors['default'])
+
+  def render(self):
+    away_colors = self.__team_colors(self.away_team.team_name)
+    away_team_color = away_colors['home']
+
+    home_colors = self.__team_colors(self.home_team.team_name)
+    home_team_color = home_colors['home']
+
+    scores_height = 14
+    for x in range(self.canvas.width):
+      for y in range(scores_height):
+        color = home_team_color if y >= scores_height / 2 else away_team_color
+        self.canvas.SetPixel(x, y, color['r'], color['g'], color['b'])
+
+    self.__render_team_text(self.away_team, away_colors, 1, 6)
+    self.__render_team_text(self.home_team, home_colors, 1, 13)
+
+  def __render_team_text(self, team, colors, x, y):
+    text_color = colors.get('text', self.colors['default']['text'])
+    text_color_graphic = graphics.Color(text_color['r'], text_color['g'], text_color['b'])
+    team_text = '{:3s}'.format(team.team_name.upper()) + ' ' + str(team.runs)
+    graphics.DrawText(self.canvas, self.font, x, y, text_color_graphic, team_text)

--- a/utils.py
+++ b/utils.py
@@ -12,9 +12,6 @@ def get_font():
   font.LoadFont(get_file('Assets/tom-thumb.bdf'))
   return font
 
-def get_team_colors():
-  return json.load(open(get_file('Assets/colors.json')))
-
 def bump_counter(counter, arr):
   counter += 1
   if counter >= len(arr):
@@ -23,7 +20,7 @@ def bump_counter(counter, arr):
 
 def args():
   parser = argparse.ArgumentParser()
-    
+
   # Options for the rpi-rgb-led-matrix library
   parser.add_argument("--led-rows", action="store", help="Display rows. 16 for 16x32, 32 for 32x32. (Default: 32)", default=32, type=int)
   parser.add_argument("--led-cols", action="store", help="Panel columns. Typically 32 or 64. (Default: 32)", default=32, type=int)
@@ -48,7 +45,7 @@ def led_matrix_options(args):
 
   if args.led_gpio_mapping != None:
     options.hardware_mapping = args.led_gpio_mapping
-  
+
   options.rows = args.led_rows
   options.cols = args.led_cols
   options.chain_length = args.led_chain
@@ -62,7 +59,7 @@ def led_matrix_options(args):
 
   if args.led_show_refresh:
     options.show_refresh_rate = 1
-  
+
   if args.led_slowdown_gpio != None:
     options.gpio_slowdown = args.led_slowdown_gpio
 

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,5 @@
 from rgbmatrix import RGBMatrixOptions, graphics
 import argparse
-import json
 import os
 
 def get_file(path):


### PR DESCRIPTION
A previous PR included moving the pixel coordinates out to another file but I'll tackle that later. This is just splitting up the scoreboard renderer into smaller ones that do one thing.

Thought about adding debug strings to each of them but it didn't seem necessary at the moment as their behavior is very simple.